### PR TITLE
Feature/change to use session storage for tab ids

### DIFF
--- a/src/background-script-handler.ts
+++ b/src/background-script-handler.ts
@@ -72,8 +72,6 @@ export namespace BackgroundScriptHandler {
 
                 storage
                 .saveTabId(tabId)
-                .then(() => storage.loadAllTabIds())
-                .then((tabIds) => console.log('insert tabId...', tabId, tabIds))
                 .catch((err) => console.error(err));
 
                 return;
@@ -86,8 +84,6 @@ export namespace BackgroundScriptHandler {
     ): void {
         const itemId  = info.menuItemId
         const storage = new Storage();
-
-        console.log('contextMenuClicked...', tab?.id);
 
         storage
         .loadConversionMode()
@@ -117,8 +113,6 @@ export namespace BackgroundScriptHandler {
             const msg        = msgFactory.createMessageContextMenuClickedEvent();
             
             for (const tabId of tabIds) {
-                console.log('sendMessage...onContextMenuClicked', tabId);
-                
                 chrome.tabs
                 .sendMessage(tabId, msg)
                 .catch((err) => console.error(err));
@@ -134,8 +128,6 @@ export namespace BackgroundScriptHandler {
 
         storage
         .deleteTabId(tabId)
-        .then(() => storage.loadAllTabIds())
-        .then((tabIds) => console.log('remove tabId...', tabId, tabIds))
         .catch((err) => console.error(err));
     }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -41,7 +41,7 @@ export class Storage {
     }
     public loadAllTabIds(): Promise<Array<number>> {
         return (
-            chrome.storage.local
+            chrome.storage.session
             .get()
             .then((result) => {
                 const tabIds = new Array<number>();
@@ -68,7 +68,7 @@ export class Storage {
             なのでデータ構造もそれに制約を受け、tabIdを配列形式で保存しておくということができない。
         */
         return (
-            chrome.storage.local
+            chrome.storage.session
             .set({[`tabId-${tabId}`]: tabId})
         );
     }
@@ -80,7 +80,7 @@ export class Storage {
             なのでデータ構造もそれに制約を受け、tabIdを配列形式で保存しておくということができない。
         */
         return (
-            chrome.storage.local
+            chrome.storage.session
             .remove(`tabId-${tabId}`)
         );
     }


### PR DESCRIPTION
# 概要

tabIdの保管場所はブラウザセッションで十分だったので修正